### PR TITLE
fix: add buildhook to rollup copy plugin

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,6 +23,7 @@ export default {
     }),
     terser({ output: { comments: false } }),
     copy({
+      hook: 'buildStart',
       targets: [
         { src: 'src/assets/**/*', dest: 'build/src' },
         { src: 'src/style/**/*', dest: 'build/src' }
@@ -30,6 +31,7 @@ export default {
       flatten: false
     }),
     copy({
+      hook: 'buildStart',
       targets: [{ src: 'data/**/*', dest: 'build/data' }],
       flatten: false
     })


### PR DESCRIPTION
When we start adding the workbox stuff, we're gonna bump into the problem that files are copied _after_ workbox has run (meaning that workbox wont precache them), so we move the copy plugin to the `buildStart` hook, so we're sure the files are in the dist folder when workbox runs