### PR TITLE
feat: implement geolocation

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,7 +19,11 @@ export default {
     babel({
       babelHelpers: 'bundled',
       presets: [require.resolve('@babel/preset-modules')],
-      plugins: [[require.resolve('babel-plugin-bundled-import-meta'), { importStyle: 'baseURI' }]]
+      plugins: [
+        [require.resolve('babel-plugin-bundled-import-meta'), { importStyle: 'baseURI' }],
+        require.resolve('@babel/plugin-proposal-optional-chaining'),
+        require.resolve('@babel/plugin-proposal-nullish-coalescing-operator'),
+      ]
     }),
     terser({ output: { comments: false } }),
     copy({

--- a/src/components/WorldMap.js
+++ b/src/components/WorldMap.js
@@ -7,6 +7,10 @@ import { router } from '../router.js';
 const mapbox_token = 'pk.eyJ1IjoibWlibG9uIiwiYSI6ImNrMGtvajhwaDBsdHQzbm16cGtkcHZlaXUifQ.dJTOE8FJc801TAT0yUhn3g';
 const today = new Date();
 
+function getCoords() {
+  return localStorage.getItem('geolocation')?.split(',');
+}
+
 export class WorldMap extends Component {
   async componentDidMount() {
     const { countriesData } = this.props;
@@ -109,6 +113,11 @@ export class WorldMap extends Component {
     this.setState({
       map
     });
+
+    if (localStorage.getItem('geolocation')) {
+      const [lat, long] = getCoords();
+      map.setView([lat, long], 5);
+    }
   }
 
   componentWillUnmount() {

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -8,7 +8,9 @@ import { router } from '../router.js';
 export class MainPage extends Component {
   constructor() {
     super();
-
+    this.state = {
+      location: {}
+    };
     this.__onPathChanged = this.__onPathChanged.bind(this);
     this.__closeCountryInfo = this.__closeCountryInfo.bind(this);
   }
@@ -17,6 +19,10 @@ export class MainPage extends Component {
     const countriesData = await (await fetch(new URL('../../data/datafile.json', import.meta.url))).json();
     this.setState({ countriesData });
     this.__onPathChanged();
+
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(this.handleGeolocation.bind(this));
+    }
   }
 
   componentWillMount() {
@@ -27,7 +33,18 @@ export class MainPage extends Component {
     router.removeEventListener('path-changed', this.__onPathChanged);
   }
 
-  render() {
+  handleGeolocation(pos) {
+    const { latitude, longitude } = pos.coords;
+    localStorage.setItem('geolocation', `${latitude},${longitude}`);
+    this.setState({
+      location: {
+        latitude,
+        longitude
+      }
+    });
+  }
+
+  render(_, { location }) {
     if (!this.state.countriesData) {
       // Loading state here
       return html``;
@@ -35,7 +52,8 @@ export class MainPage extends Component {
 
     return html`
       <${Totals} />
-      <${WorldMap} countriesData=${this.state.countriesData} />
+      <${WorldMap} countriesData=${this.state.countriesData} location=${location} />
+
       ${this.state.selectedCountry
         ? html`
             <${CountryInfo}


### PR DESCRIPTION
Gets the users geolocation, and 'snaps' the map to the region of where the user is located

![Mar-22-2020 00-49-03](https://user-images.githubusercontent.com/17054057/77239098-02f56a00-6bd7-11ea-8371-e421a2e78da5.gif)

There's something to be said about requesting permission for geolocation on pageload, it may not be the best UX. Since the ux design is still a little bit unclear for now, I'm just leaving it for now, and we can improve on it in the future.