### PR TITLE
fix: axios not de-serializing URLSearchParams correctly

### DIFF
--- a/backend/src/utils/CustomGoogleSpreadsheet.js
+++ b/backend/src/utils/CustomGoogleSpreadsheet.js
@@ -16,9 +16,7 @@ export class CustomGoogleSpreadsheet extends GoogleSpreadsheet {
       params.append('ranges', range);
     });
     
-    const result = await this.axios.get('/values:batchGet', {
-      params
-    });
+    const result = await this.axios.get(`/values:batchGet?${params.toString()}`);
 
     return (result.data.valueRanges || []).map(d => d['values']);
   }


### PR DESCRIPTION
Fixes empty data result on `batchGet` google spreadsheet queries. Probably caused by a change somewhere in dependencies, since this worked in my existing repository (and previous github CI update data runs), but does not in a fresh clone.