### PR TITLE
fix: logic issue for lockdown status

### DIFF
--- a/backend/src/loaders/lockdown/parsers/lockdownParser.js
+++ b/backend/src/loaders/lockdown/parsers/lockdownParser.js
@@ -1,5 +1,5 @@
 import { getCachedCellsRange } from '../../../utils/sheet';
-import { toMeasureType, toTravelType, toInteger, isUpdateReady, toEntryDate, toCountryStatus } from '../../../utils/typeHelper';
+import { toMeasureType, toTravelType, toInteger, isUpdateReady, toEntryDate, toLockdownType } from '../../../utils/typeHelper';
 import { TRAVEL, MEASURE } from '../../../../../shared/types';
 import { letterToColumn, columnToLetter } from 'google-spreadsheet/lib/utils';
 import DataPoint from '../types/DataPoint';
@@ -59,7 +59,7 @@ export function parseMeasure(sheet, entryIndex) {
 
   /** @type {Measure} */
   const data = {
-    lockdown_status: parseDataPoint(entryMeasureRows[0], toMeasureType),
+    lockdown_status: parseDataPoint(entryMeasureRows[0], toLockdownType),
     city_movement_restriction: parseDataPoint(entryMeasureRows[1], toMeasureType),
     attending_religious_sites: parseDataPoint(entryMeasureRows[2], toMeasureType),
     going_to_work: parseDataPoint(entryMeasureRows[3], toMeasureType),

--- a/backend/src/utils/typeHelper.js
+++ b/backend/src/utils/typeHelper.js
@@ -1,6 +1,7 @@
-import { MEASURE, LOCKDOWN, TRAVEL, UPDATE_STATUS, COUNTRY_STATUS, DATA_ENTRY_STATUS } from '../../../shared/types';
+import { MEASURE, TRAVEL, UPDATE_STATUS, COUNTRY_STATUS, DATA_ENTRY_STATUS } from '../../../shared/types';
 import moment from './moment';
 
+// Options are the literal values set in google sheet
 const OPTION_MEASURE = {
   'Yes': MEASURE.YES,
   'No': MEASURE.NO,
@@ -66,6 +67,18 @@ export function toUpdateType(value) {
   return OPTION_UPDATE_TYPE[value] ?? null;
 }
 
+// Special note on lockdown: its label is "Are citizens allowed to leave their homes?"
+// Thus the value is actually opposite, i.e: "No" means lockdown, and vice versa
+export function toLockdownType(value) {
+  switch (value) {
+    case 'No':
+      return MEASURE.YES
+    case 'Yes':
+      return MEASURE.NO
+  }
+  return OPTION_MEASURE[value] ?? null;
+}
+
 export function toInteger(value) {
   const int = parseInt(value);
   return Number.isInteger(int) ? int : null;
@@ -91,5 +104,5 @@ export function isUpdateReady(value) {
 }
 
 export function isLockdown(value) {
-  return value === LOCKDOWN.YES || value === LOCKDOWN.PARTIAL;
+  return value === MEASURE.YES || value === MEASURE.PARTIAL;
 }

--- a/backend/tests/loaders/totals.test.js
+++ b/backend/tests/loaders/totals.test.js
@@ -20,5 +20,4 @@ test('total corona', async () => {
 
   expect(typeof corona.confirmed).toEqual('number');
   expect(typeof corona.deaths).toEqual('number');
-  expect(typeof corona.date).toEqual('string');
 });

--- a/shared/types.js
+++ b/shared/types.js
@@ -20,12 +20,12 @@ const MEASURE = {
   UNCLEAR: '4',
 };
 
-const LOCKDOWN = {
-  NO: '1',
-  PARTIAL: '2',
-  YES: '3',
-  UNCLEAR: '4',
-}
+// const LOCKDOWN = {
+//   NO: '1',
+//   PARTIAL: '2',
+//   YES: '3',
+//   UNCLEAR: '4',
+// }
 
 const COUNTRY_STATUS = {
   UNCLEAR: '1',
@@ -79,5 +79,5 @@ module.exports = {
   GLOBAL_COUNTRY_STATUS: GLOBAL_COUNTRY_STATUS,
   UPDATE: UPDATE,
   UPDATE_STATUS: UPDATE_STATUS,
-  LOCKDOWN: LOCKDOWN,
+  // LOCKDOWN: LOCKDOWN,
 }


### PR DESCRIPTION
I missed the fact that in google sheet, lockdown is defined as "Are citizens allowed to leave their homes?", which means "No" is a lockdown and "Yes" is not.

Also I've reverted back to use Measure definition to fit better with existing frontend logic. Sorry that things got a little convoluted