### PR TITLE
Update Menu.js

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -144,7 +144,6 @@ const styles2 = css`
           justify-content: center;
           & ul {
             padding: 0;
-            justify-content: space-around;
             justify-content: flex-start;
             align-items: left;
             min-height: 50%;

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -146,7 +146,7 @@ const styles2 = css`
             padding: 0;
             justify-content: space-around;
             justify-content: flex-start;
-            align-items: center;
+            align-items: left;
             min-height: 50%;
             display: flex;
             flex-direction: column;


### PR DESCRIPTION
Align side tabbed menu ul to left so it is flush with content window. Change line 149 from 'align-items:center' to 'align-items:left'