### PR TITLE
Improve contrast for country and state labels and border lines

### DIFF
--- a/src/components/WorldMap.js
+++ b/src/components/WorldMap.js
@@ -283,7 +283,7 @@ export class WorldMap extends Component {
       map.setPaintProperty('settlement-minor-label','text-halo-width',0);
 
       // Change water color
-      map.setPaintProperty('water','fill-color','white');
+      map.setPaintProperty('water','fill-color','#fff');
 
 
       const setStates = (e) => {

--- a/src/components/WorldMap.js
+++ b/src/components/WorldMap.js
@@ -283,7 +283,7 @@ export class WorldMap extends Component {
       map.setPaintProperty('settlement-minor-label','text-halo-width',0);
 
       // Change water color
-      map.setPaintProperty('water','fill-color','#fff');
+      map.setPaintProperty('water','fill-color','#e0e0e0');
 
 
       const setStates = (e) => {

--- a/src/components/WorldMap.js
+++ b/src/components/WorldMap.js
@@ -240,11 +240,33 @@ export class WorldMap extends Component {
               ],
               ['case', ['boolean', ['feature-state', 'hover'], false], 'rgba(204,204,204,0.5)', 'rgba(204,204,204,0)'],
             ],
-            'fill-opacity': ['case', ['boolean', ['feature-state', 'hover'], false], 0.7, 1],
+            'fill-opacity': ['case', ['boolean', ['feature-state', 'hover'], false], 0.7, 1]
           },
         },
-        'waterway-label'
+        'admin-1-boundary-bg'
       );
+
+      //
+      // Map style adjustments
+      //
+
+      // Improve contrast of country country labels
+      map.setPaintProperty('country-label','text-color','hsl(0, 0%, 10%)');
+      map.setPaintProperty('country-label','text-halo-color','hsla(0, 0%, 100%,0.6)');
+      map.setPaintProperty('country-label','text-halo-width',1);
+
+      // Improve contrast of country state labels
+      map.setPaintProperty('state-label','text-color','hsl(0, 0%, 30%)');
+      map.setPaintProperty('state-label','text-halo-width',0);
+
+      // Improve contrast of country label lines
+      map.setPaintProperty('admin-0-boundary','line-color','hsla(0, 0%, 90%, 0.8)');
+      map.setPaintProperty('admin-0-boundary-disputed','line-color','hsla(0, 0%, 90%, 0.5)');
+      map.setPaintProperty('admin-0-boundary-bg','line-color','hsla(0, 0%, 84%, 0.3)');
+
+      // Improve contrast of country label lines
+      map.setPaintProperty('admin-1-boundary','line-color','hsla(0, 0%, 90%, 0.6)');
+
 
       const setStates = (e) => {
         // console.log('setStates');

--- a/src/components/WorldMap.js
+++ b/src/components/WorldMap.js
@@ -28,6 +28,8 @@ const domainCoors = {
   africa: { lng: 21.525828, lat: 4.214943, zoom: 3.2 }, //Somewhere in Africa :)
 };
 
+// Use for altering boundaries of countries with disputed areas
+// Options: https://docs.mapbox.com/vector-tiles/reference/mapbox-boundaries-v3/#--polygon---worldview-text
 const selectedWorldview='US';
 
 const pause = (time = 100) => {
@@ -243,10 +245,12 @@ export class WorldMap extends Component {
                 worldStyle('4'),
                 worldStyle('0'),
               ],
+              // No data
               ['==', ['feature-state', 'kind'], null],
               worldStyle('0'),
               ['case', ['boolean', ['feature-state', 'hover'], false], 'rgba(204,204,204,0.5)', 'rgba(204,204,204,0)'],
             ],
+            // Hover style
             'fill-opacity': ['case', ['boolean', ['feature-state', 'hover'], false], 0.7, 1]
           },
         },
@@ -277,8 +281,8 @@ export class WorldMap extends Component {
       // Improve contrast of city labels
       map.setPaintProperty('settlement-major-label','text-halo-width',0);
       map.setPaintProperty('settlement-minor-label','text-halo-width',0);
-      map.setPaintProperty('settlement-subdivision-label','text-halo-width',0);
 
+      // Change water color
       map.setPaintProperty('water','fill-color','white');
 
 


### PR DESCRIPTION
- Move 'admin-0-fill' layer before the 'admin-1-boundary-bg' boundary line layers
- Add runtime map style improvements for improved contrast of:
  - Country and state labels
  - Country and state lines
- Make water white for improved contrast with land
- Fix implementation of default color for no values or undefined lockdown values
- Create a variable `selectedWorldview` to easily control the boundary version for disputed areas in future. Ref: https://docs.mapbox.com/vector-tiles/reference/mapbox-boundaries-v3/#--polygon---worldview-text
  

Before

<img width="1108" alt="Screen Shot 2020-05-13 at 7 37 03 PM" src="https://user-images.githubusercontent.com/126868/81876661-37d7ca80-9551-11ea-8857-7588c13bf8e1.png">

After

<img width="1017" alt="Screen Shot 2020-05-13 at 7 37 22 PM" src="https://user-images.githubusercontent.com/126868/81876664-38706100-9551-11ea-9f5a-2b1cfdf3200d.png">

cc @aherreDev @JFQueralt 