### PR TITLE
Add workaround for fill-pattern by using a case expression

### DIFF
--- a/src/components/WorldMap.js
+++ b/src/components/WorldMap.js
@@ -390,7 +390,16 @@ export class WorldMap extends Component {
       map.setPaintProperty('water', 'fill-color', '#e0e0e0');
 
       const setStates = (e) => {
+
+        // Start a case expression for the pattern fill
+        let fillPatternExpression=['case'];
+
         localData.forEach(function (row) {
+
+          // Add the condition and output value for the pattern
+          fillPatternExpression.push(['==', ['id'], lookupData[row.lockdown.iso].feature_id])
+          fillPatternExpression.push(worldPattern(row.lockdown.measure[0].value))
+
           map.setFeatureState(
             {
               source: 'admin-0',
@@ -403,6 +412,15 @@ export class WorldMap extends Component {
             }
           );
         });
+
+        // Add fallback pattern
+        fillPatternExpression.push(worldPattern(0))
+
+        // Update layer style
+        map.setPaintProperty('admin-0-pattern','fill-pattern',fillPatternExpression)
+
+        // DEBUG
+        console.log(fillPatternExpression)
 
         this.setState({
           isMapReady: true,


### PR DESCRIPTION
Workaround to styling polygon fill-paterns using a case expression targeting feature_id.

This is due to the limitation in Mapbox GL that does not allowing changing fill-pattern using the feature state  https://github.com/mapbox/mapbox-gl-js/issues/9733

<img width="974" alt="Screen Shot 2020-05-29 at 6 11 06 PM" src="https://user-images.githubusercontent.com/126868/83309772-2ab90d80-a1d8-11ea-9492-75fc01ed0031.png">


@aherreDev