### PR TITLE
[Add] the folder "translations" to the rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -83,6 +83,11 @@ export default [
       }),
       copy({
         hook: 'buildStart',
+        targets: [{ src: 'src/locale/translations', dest: 'build/' }],
+        flatten: true
+      }),
+      copy({
+        hook: 'buildStart',
         targets: [
           { src: 'manifest.json', dest: 'build/' },
           { src: 'manifest-dark.json', dest: 'build/' }


### PR DESCRIPTION
# Explanation
The es-dev-server return a 404 status because the /translation folder not exist on the build script