### PR TITLE
When data is deleted in GSheet, they still remain in CosmosDB

### DIFF
--- a/backend/src/loaders/lockdown/lockdown.js
+++ b/backend/src/loaders/lockdown/lockdown.js
@@ -79,6 +79,12 @@ export async function batchGetTerritoriesEntryData(territories) {
             if (insertResult.find(r => r.result.nModified == 0 && r.result.ok == 1)) {
               shouldResetApiCache = true;
             }
+          } else {
+            // country sheet where entries are blank - we need to delete snapshots for the country in the db
+            var clearResult = await Promise.all(database.snapshotRepository.clear());
+            if (clearResult.find(r => r.result.ok == 1)) {
+              shouldResetApiCache = true;
+            }
           }
 
           result.push({


### PR DESCRIPTION
Country sheet where entries are blank - we need to delete snapshots for the country in the db
Please review and test (sorry I couldn't test the code without access to GSheet, GitHub action and Cosmos DB (MongoDB in Azure).
Please backup data before running for the first time as data may be deleted.