### PR TITLE
Bug fix: updateMany atomic operators MongoError. using insertMany instead.

### DIFF
--- a/backend/src/loaders/lockdown/lockdown.js
+++ b/backend/src/loaders/lockdown/lockdown.js
@@ -70,12 +70,17 @@ export async function batchGetTerritoriesEntryData(territories) {
 
           let snapshots = getSnapshots(entries);
 
-          // country sheet where entries are blank - we need to delete snapshots for the country in the db
-          // 21/6/2020 NPIs also have the same issue - delete country entries first before inserting.
-          var clearResult = await database.snapshotRepository.removeSnapshots(batch[i]['iso2'], batch[i]['iso3']);
-          logger.log(`clearResult: ${clearResult}`);
-          if (clearResult.result.n > 0 && clearResult.result.ok == 1) {
-            shouldResetApiCache = true;
+          try {
+            // country sheet where entries are blank - we need to delete snapshots for the country in the db
+            // 21/6/2020 NPIs also have the same issue - delete country entries first before inserting.
+            let clearResult = await database.snapshotRepository.removeSnapshots(batch[i]['iso2'], batch[i]['iso3']);
+            // example of clearResult is {"result":{"n":0,"ok":1},"connection":{"id":1,"host":"***","port":111},"deletedCount":0,"n":0,"ok":1}
+            if (clearResult.result.n > 0 && clearResult.result.ok == 1) {
+              shouldResetApiCache = true;
+            }
+          } catch (error) {
+            logger.log(`Error removeSnapshots for country ${batch[i]['iso2']} ${batch[i]['iso3']}...`);
+            logger.error(error);
           }
 
           if (snapshots.length > 0) {
@@ -83,9 +88,16 @@ export async function batchGetTerritoriesEntryData(territories) {
               s.iso3 = batch[i]['iso3'];
               s.iso2 = batch[i]['iso2'];
             });
-            var insertResult = await Promise.all(database.snapshotRepository.insertManyOrUpdate(snapshots));
-            if (insertResult.find(r => r.result.nModified == 0 && r.result.ok == 1)) {
-              shouldResetApiCache = true;
+
+            try {
+              let insertResult = await database.snapshotRepository.insertMany(snapshots);
+              // reference: http://mongodb.github.io/node-mongodb-native/3.5/api/Collection.html#~insertWriteOpResult
+              if (insertResult.result.n > 0 && insertResult.result.ok == 1) {
+                shouldResetApiCache = true;
+              }
+            } catch (error) {
+              logger.log(`Error insertMany for country ${batch[i]['iso2']} ${batch[i]['iso3']}...`);
+              logger.error(error);
             }
           }
 

--- a/backend/src/repositories/SnapshotRepository.js
+++ b/backend/src/repositories/SnapshotRepository.js
@@ -202,6 +202,7 @@ export default class SnapshotRepository {
     return this.model.insertMany(snaphots);
   }
 
+  // referenece: https://docs.mongodb.com/manual/reference/method/db.collection.updateMany/
   insertManyOrUpdate(snapshots) {
     return snapshots.map((s) => {
       return this.model.updateMany(
@@ -210,7 +211,7 @@ export default class SnapshotRepository {
           start_date: s.start_date,
           end_date: s.end_date,
         },
-        s,
+        { $set: s },
         { upsert: true }
       );
     });
@@ -239,7 +240,7 @@ export default class SnapshotRepository {
 
   /**
    *
-   * Clears the entire database of all values, we won't want to call this.
+   * Clears the entire database of all values, we won't want to call this unless we are sure.
    * @returns {Promise}
    */
   clear() {


### PR DESCRIPTION
Since we removed snapshots prior to inserting, we don't need to use updateMany. using insertMany instead. Added try / catch, fix updateMany MongoError: the update operation document must contain atomic operators.